### PR TITLE
Fix Behaviour of Method Get

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -75,7 +75,7 @@ func (h *Histogram) checkInitialized() {
 	}
 }
 
-// Get returns the count for value v. Automatically performs interpolation if needed.
+// Get returns the frequency for value v.
 func (h *Histogram) Get(v int) (float64, error) {
 	h.checkInitialized()
 
@@ -85,10 +85,21 @@ func (h *Histogram) Get(v int) (float64, error) {
 
 	count, ok := h.values[v]
 	if !ok {
-		count = h.interpolateValue(v, h.values)
+		return 0, nil
 	}
 
 	return count, nil
+}
+
+// Get returns the frequency for value v. Automatically performs interpolation if needed.
+func (h *Histogram) GetInterpolated(v int) (float64, error) {
+	count, err := h.Get(v)
+
+	if count == 0 && err == nil {
+		count = h.interpolateValue(v, h.values)
+	}
+
+	return count, err
 }
 
 // GetPercentile returns the percentile position for value v. Automatically performs interpolation if needed.

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -27,11 +27,22 @@ func (s *HistogramSuite) TestHistogram_Get(c *C) {
 	h := createSampleHistogram()
 
 	assertHistogramGet(c, h, 100, 2.0)
-	assertHistogramGet(c, h, 300, 3.0)
+	assertHistogramGet(c, h, 300, 0.0)
 	assertHistogramGet(c, h, 500, 4.0)
-	assertHistogramGet(c, h, 700, 3.5)
+	assertHistogramGet(c, h, 700, 0.0)
 	assertHistogramGet(c, h, 900, 3.0)
 	assertHistogramGet(c, h, 1000, 1.0)
+}
+
+func (s *HistogramSuite) TestHistogram_GetInterpolated(c *C) {
+	h := createSampleHistogram()
+
+	assertHistogramGetInterpolated(c, h, 100, 2.0)
+	assertHistogramGetInterpolated(c, h, 300, 3.0)
+	assertHistogramGetInterpolated(c, h, 500, 4.0)
+	assertHistogramGetInterpolated(c, h, 700, 3.5)
+	assertHistogramGetInterpolated(c, h, 900, 3.0)
+	assertHistogramGetInterpolated(c, h, 1000, 1.0)
 }
 
 func (s *HistogramSuite) TestHistogram_GetOutOfBounds(c *C) {
@@ -45,6 +56,12 @@ func (s *HistogramSuite) TestHistogram_GetOutOfBounds(c *C) {
 
 func assertHistogramGet(c *C, h *Histogram, v int, expected float64) {
 	res, err := h.Get(v)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, expected)
+}
+
+func assertHistogramGetInterpolated(c *C, h *Histogram, v int, expected float64) {
+	res, err := h.GetInterpolated(v)
 	c.Assert(err, IsNil)
 	c.Assert(res, Equals, expected)
 }


### PR DESCRIPTION
The `Get` method of the histogram automatically interpolates the frequency of the requested bin when it is 0. This prevents the raw data to be accessed if necessary (i.e.: it is not possible to check if a bin has 0 frequency).

This PR fixes this behavior, and creates a new method `GetInterpolated` to retrieve interpolated frequencies when needed.
